### PR TITLE
Relação tabela muitos para um campeonato e partida

### DIFF
--- a/src/main/java/lucas/duarte/jazz/controller/CampeonatoController.java
+++ b/src/main/java/lucas/duarte/jazz/controller/CampeonatoController.java
@@ -50,7 +50,7 @@ public class CampeonatoController {
 			ObjectNode objectNode1 = mapper.createObjectNode();
 			objectNode1.put("id", c.getId());
 			objectNode1.put("nome", c.getNome());
-			
+
 			campeonatos.add(objectNode1);
 		}
 		return responseController.responseController(campeonatos, HttpStatus.OK);
@@ -59,9 +59,8 @@ public class CampeonatoController {
 	// Create Partida
 	@RequestMapping(value = "/campeonato/", method = RequestMethod.POST)
 	public ResponseEntity<?> createCampeonato(@RequestBody Campeonato camp, UriComponentsBuilder ucBuilder) {
-		// Apenas retorna a trataviva do service
-		System.out.println("Vou cadastrar um campeonato");
-		return campeonatoServ.salvarCampeonato(camp);
+		campeonatoServ.processaEntidade(camp);
+		return null;
 
 	}
 

--- a/src/main/java/lucas/duarte/jazz/model/service/CampeonatoService.java
+++ b/src/main/java/lucas/duarte/jazz/model/service/CampeonatoService.java
@@ -8,12 +8,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import lucas.duarte.jazz.model.bean.Campeonato;
+import lucas.duarte.jazz.model.bean.Partida;
 import lucas.duarte.jazz.model.repository.CampeonatoRepository;
 
 @Service
 public class CampeonatoService {
 	@Autowired
 	private CampeonatoRepository campeonatoRepo;
+
+	@Autowired
+	private PartidaService partidaService;
 
 	public ResponseEntity<Campeonato> salvarCampeonato(Campeonato camp) {
 		try {
@@ -32,13 +36,23 @@ public class CampeonatoService {
 		if (campeonatos.isEmpty()) {
 			// Return 404 beacause was not found
 			return new ResponseEntity(HttpStatus.NOT_FOUND);
-		}else {
+		} else {
 			return new ResponseEntity<List<Campeonato>>(campeonatos, HttpStatus.OK);
 		}
 
 	}
-	
+
 	public List<Campeonato> getAllCampeonatosNameId() {
 		return campeonatoRepo.findAllByNameAndId();
+	}
+
+	public void processaEntidade(Campeonato campeonato) {
+		List<Partida> partidas = campeonato.getPartidas();
+		campeonato.setPartidas(null);
+		campeonato = campeonatoRepo.save(campeonato);
+		for (Partida partida : partidas) {
+			partida.setCampeonato(campeonato);
+			partidaService.cadastrarPartida(partida);
+		}
 	}
 }


### PR DESCRIPTION
<h2>Foi feito a relação das tabelas Campeonato e Partida, com os respectivos ID's do campeonato que for selecionado no front</h2>

<li>Eu tive que usar uma logica alternativa porém funciona, pelo fato de que tentei usar só as anotações JPA e nada funcionava, cai em um serie de erros doidos ( Erros típicos de relação N -> 1 )</li>
<li>Fiz desta forma pq assim não precisa de validação de campeonato para cadastrar a partida, pois as tabelas já estão correlacionados</li>
<h4> Teste desta forma </h4>

![image](https://user-images.githubusercontent.com/37024180/57991369-bdcb4d80-7a84-11e9-9f9e-654ef15e0231.png)



<li>O id não precisa, pq ele esta como auto incremento</li>
<li>Retorno</li>
<li>A coluna campeonato não e mais gerada na tabela partida</li> 

![image](https://user-images.githubusercontent.com/37024180/57991419-29adb600-7a85-11e9-96fb-f07116fdd3ca.png)

<li>Estou recuperando ela pela seguinte linha de código</li>
<li>Setado no ( End Point Campo campeonato em partidas )</li>


![image](https://user-images.githubusercontent.com/37024180/57991458-74c7c900-7a85-11e9-8e6b-494e56fe3a1c.png)






