### PR TITLE
Cadastrar Set Vazio a uma partida nao iniciada.

### DIFF
--- a/src/main/java/lucas/duarte/jazz/controller/PartidaController.java
+++ b/src/main/java/lucas/duarte/jazz/controller/PartidaController.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import lucas.duarte.jazz.model.bean.Partida;
+import lucas.duarte.jazz.model.bean.Set;
 import lucas.duarte.jazz.model.service.PartidaService;
 
 @RestController
@@ -42,7 +43,11 @@ public class PartidaController {
 
 	@RequestMapping(value = "/partidas/", method = RequestMethod.POST)
 	public ResponseEntity<?> createPartida(@RequestBody Partida partida, UriComponentsBuilder ucBuilder) {
-		if (partidaServ.cadastrarPartida(partida)) {
+		Set setPartida = new Set();
+		setPartida.setPartida(partida);
+		
+		boolean cadastroPartida = partidaServ.cadastrarPartida(partida, setPartida);
+		if (cadastroPartida) {
 			return responseController.responseController(partida, HttpStatus.OK);
 			// return new ResponseEntity<Partida>(partida, HttpStatus.CREATED);
 		} else {

--- a/src/main/java/lucas/duarte/jazz/model/service/PartidaService.java
+++ b/src/main/java/lucas/duarte/jazz/model/service/PartidaService.java
@@ -6,16 +6,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import lucas.duarte.jazz.model.bean.Partida;
+import lucas.duarte.jazz.model.bean.Set;
 import lucas.duarte.jazz.model.repository.PartidaRepository;
 
 @Service
 public class PartidaService {
 	@Autowired
 	private PartidaRepository partidaRepo;
+	@Autowired
+	private SetService setService;
 
-	public boolean cadastrarPartida(Partida partida) {
+	public boolean cadastrarPartida(Partida partida, Set set) {
 		try {
 			partidaRepo.save(partida);
+			setService.salvarSet(set);
 			return true;
 		} catch (Exception e) {
 			System.out.println(e);


### PR DESCRIPTION
- Solicitado pelo Bruno ao cadastrar uma partida sempre adicionar um set vazio junto.
- Foi criado o service do set dentro da chamada do service de cadastrar partida.
- Testado com o Postman ele inicializa um SET.